### PR TITLE
docs: Add CHANGELOG for UDCL legal framework repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# CHANGELOG — Ordenamento Jurídico da UDCL
+
+Registro cronológico de todas as alterações normativas do repositório.
+
+---
+
+## [1.0.0] — 2026-02-11
+
+### Fundação do Repositório
+
+Migração inaugural do ordenamento jurídico completo da UDCL para o GitHub.
+
+**Estado inicial — 10 diplomas normativos:**
+
+- **CUDCL** — Constituição da UDCL (~110 artigos)
+- **CCR** — Código Civil da Resenha (~300 artigos)
+- **CPA** — Código Penal da Amizade (~142 artigos)
+- **CAR** — Código Administrativo da Resenha (~76 artigos)
+- **CTR** — Código de Tributação e Rateio (~67 artigos)
+- **CLT** — Código do Lazer e Tempo Livre (~80 artigos)
+- **CLTE** — Código de Lazer, Trabalho e Economia (~70 artigos)
+- **CPC** — Código de Processo Civil da Resenha (~92 artigos)
+- **CPP** — Código de Processo Penal Fraterno (~89 artigos)
+- **MHS** — Manual de Heráldica e Símbolos (~84 artigos)
+
+**Documentação técnica:**
+
+- Manual Técnico de Operações (OOC)
+
+**Totais:**
+
+- 10 diplomas normativos
+- ~1.000+ artigos
+- 13.385 linhas de texto normativo
+
+**Período:** Pré-Ciclo 1 (fundação e consolidação)
+
+**Era:** 1º Ano da Era da Legalidade Lúdica
+
+---
+
+*Formato baseado em [Keep a Changelog](https://keepachangelog.com/).*


### PR DESCRIPTION
## Summary

This PR introduces a CHANGELOG document to track normative changes and versions of the UDCL (Ordenamento Jurídico da UDCL) legal framework repository.

## Changes

- **Added CHANGELOG.md** — Initial changelog documenting the repository's foundation (v1.0.0)
  - Records the inaugural migration of the complete UDCL legal system to GitHub
  - Documents the initial state: 10 normative diplomas (~1,000+ articles across 13,385 lines)
  - Lists all foundational legal codes including Constitution (CUDCL), Civil Code (CCR), Penal Code (CPA), and others
  - Includes technical documentation reference (OOC Manual)
  - Follows [Keep a Changelog](https://keepachangelog.com/) format for consistency and maintainability

## Context

This changelog serves as the official record of the repository's normative evolution, establishing version 1.0.0 as the baseline for the UDCL legal framework during the "1º Ano da Era da Legalidade Lúdica" (1st Year of the Playful Legality Era).

https://claude.ai/code/session_01QiHZxQJhhfkSq4ot7NHvVJ